### PR TITLE
"Forever log" as a stable memory log that never forgets.

### DIFF
--- a/motoko/library/State.mo
+++ b/motoko/library/State.mo
@@ -33,9 +33,11 @@ module {
 
   public module Event {
     public type CreateProfile = {
+      caller : Principal;
       userName : Text;
     };
     public type CreateView = {
+      caller : Principal;
       createUser : Types.UserId;
       createTime : Int;
       targets : Types.View.Target.Targets;
@@ -77,6 +79,7 @@ module {
   public module Space {
     /// Space of puts.
     public type Space = {
+      createCaller : Principal;
       createUser : Types.UserId;
       createTime : Int;
       path : Path;
@@ -87,7 +90,8 @@ module {
     /// cloned space is not affected by updates to original object;
     /// specifically, cloned space has cloned put sequence.
     public func clone(s : Space) : Space {
-      { createUser = s.createUser ;
+      { createCaller = s.createCaller ;
+        createUser = s.createUser ;
         createTime = s.createTime ;
         puts = s.puts.clone() ;
         path = s.path ;

--- a/motoko/library/State.mo
+++ b/motoko/library/State.mo
@@ -43,6 +43,7 @@ module {
       ttl : ?Nat;
     };
     public type Put = {
+      caller : Principal;
       user : Types.UserId;
       path : Path;
       values : [ Types.Candid.Value.Value ];


### PR DESCRIPTION
Permits any caller to put a verified candid value at a path of their choosing, recording it in the "forever log".

Also records other events in the forever log as well.

Once deployed, will use this "forever log" to never forget any past put values, across all upgrades.  This permits us to recover from any issue by retrying different upgrade hooks to reread the "forever log" in different ways, perhaps failing several times without loosing data.

Addresses #6 