### PR TITLE
Caniput Feature: Log file tree traversal.

### DIFF
--- a/rust/caniput/src/bin/caniput.rs
+++ b/rust/caniput/src/bin/caniput.rs
@@ -226,6 +226,7 @@ async fn main() -> OurResult<()> {
             service_call(&cc, &ServiceCall::Put(vec!(put_path), vec!(ast))).await?;
         },
         CliCommand::PutTree { put_path, local_path } => {
+            info!("Reading local tree from path {}", local_path);
             let file = caniput::ast::file_of_path(std::path::Path::new(&local_path))?;
             let ast = Value::File(Box::new(file));
             service_call(&cc, &ServiceCall::Put(vec!(put_path), vec!(ast))).await?;

--- a/rust/caniput/src/lib/ast.rs
+++ b/rust/caniput/src/lib/ast.rs
@@ -1,13 +1,13 @@
 pub use candid::parser::value::IDLValue as ParsedValue;
 
-use candid::parser::value::IDLField as ParsedField;
 use candid::parser::value::IDLArgs as ParsedArgs;
+use candid::parser::value::IDLField as ParsedField;
 use candid::types::Label as ParsedLabel;
 
-use candid::{Nat, Int};
 use candid::{CandidType, Deserialize};
+use candid::{Int, Nat};
 
-use log::{info, debug};
+use log::{debug, info};
 
 use crate::error::*;
 
@@ -90,17 +90,17 @@ impl From<&ParsedLabel> for Label {
 
 impl From<&ParsedArgs> for Args {
     fn from(a: &ParsedArgs) -> Args {
-        let mut v2 = vec!();
+        let mut v2 = vec![];
         for v in a.args.iter() {
             v2.push(Value::from(v))
-        };
-        Args{ args: v2 }
+        }
+        Args { args: v2 }
     }
 }
 
 impl From<&ParsedField> for Field {
     fn from(f: &ParsedField) -> Field {
-        Field{
+        Field {
             id: Label::from(&f.id),
             val: Value::from(&f.val),
         }
@@ -117,18 +117,20 @@ impl From<&ParsedValue> for Value {
             ParsedValue::Float64(f) => Value::Float64(*f),
             ParsedValue::Opt(v) => Value::Opt(Box::new(Value::from(&**v))),
             ParsedValue::Vec(v1) => {
-                let mut v2 = vec!();
-                for v in v1.iter() { v2.push(Value::from(v)) };
+                let mut v2 = vec![];
+                for v in v1.iter() {
+                    v2.push(Value::from(v))
+                }
                 Value::Vec(v2)
-            },
-            ParsedValue::Variant(vv) => {
-                Value::Variant(Box::new(Field::from(&*vv.0)))
-            },
+            }
+            ParsedValue::Variant(vv) => Value::Variant(Box::new(Field::from(&*vv.0))),
             ParsedValue::Record(fs1) => {
-                let mut fs2 = vec!();
-                for f in fs1.iter() { fs2.push(Field::from(f)) };
+                let mut fs2 = vec![];
+                for f in fs1.iter() {
+                    fs2.push(Field::from(f))
+                }
                 Value::Record(fs2)
-            },
+            }
             ParsedValue::Principal(p) => Value::Principal(p.clone()),
             ParsedValue::Service(p) => Value::Service(p.clone()),
             ParsedValue::Func(p, s) => Value::Func(p.clone(), s.clone()),
@@ -153,22 +155,22 @@ impl From<&ParsedValue> for Value {
 pub fn file_of_path(path: &std::path::Path) -> OurResult<File> {
     info!("Reading path {:?}", path);
     if path.is_dir() {
-        let mut name_files = vec!();
+        let mut name_files = vec![];
         for entry in std::fs::read_dir(path)? {
             let entry = entry?;
             let name = entry.file_name().to_str().unwrap().to_string();
             let file = file_of_path(&entry.path())?;
-            name_files.push(NameFile{name, file});
+            name_files.push(NameFile { name, file });
         }
         Ok(File::Directory(name_files))
     } else {
         let s = std::fs::read_to_string(path)?;
-        let pv : Result<ParsedValue, _> = s.parse();
+        let pv: Result<ParsedValue, _> = s.parse();
         if let Ok(v) = pv {
             debug!("Parsed value {}", v);
             Ok(File::Value(Value::from(&v)))
         } else {
-            let pa : Result<ParsedArgs, _> = s.parse();
+            let pa: Result<ParsedArgs, _> = s.parse();
             if let Ok(a) = pa {
                 debug!("Parsed args {}", a);
                 Ok(File::Args(Args::from(&a)))

--- a/rust/caniput/src/lib/ast.rs
+++ b/rust/caniput/src/lib/ast.rs
@@ -7,6 +7,8 @@ use candid::types::Label as ParsedLabel;
 use candid::{Nat, Int};
 use candid::{CandidType, Deserialize};
 
+use log::{info, debug};
+
 use crate::error::*;
 
 #[derive(PartialEq, Clone, CandidType, Deserialize)]
@@ -149,6 +151,7 @@ impl From<&ParsedValue> for Value {
 
 /// Read filesystem starting at `path`, and construct a `File`.
 pub fn file_of_path(path: &std::path::Path) -> OurResult<File> {
+    info!("Reading path {:?}", path);
     if path.is_dir() {
         let mut name_files = vec!();
         for entry in std::fs::read_dir(path)? {
@@ -162,10 +165,12 @@ pub fn file_of_path(path: &std::path::Path) -> OurResult<File> {
         let s = std::fs::read_to_string(path)?;
         let pv : Result<ParsedValue, _> = s.parse();
         if let Ok(v) = pv {
+            debug!("Parsed value {}", v);
             Ok(File::Value(Value::from(&v)))
         } else {
             let pa : Result<ParsedArgs, _> = s.parse();
             if let Ok(a) = pa {
+                debug!("Parsed args {}", a);
                 Ok(File::Args(Args::from(&a)))
             } else {
                 Ok(File::Text(s))


### PR DESCRIPTION
This PR adds the `Reading path` and `Parsed` log lines in the example log given below.

```
[2021-06-16T20:04:15Z INFO  caniput] Evaluating CLI command: PutTree { put_path: "test", local_path: "../../test/service/putTree" } ...
[2021-06-16T20:04:15Z INFO  caniput] Reading local tree from path ../../test/service/putTree
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree"
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/apple"
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/apple/vecOneTwoThree"
[2021-06-16T20:04:15Z DEBUG caniput::ast] Parsed value vec { 1; 2; 3 }
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/apple/oneTwoThree"
[2021-06-16T20:04:15Z DEBUG caniput::ast] Parsed args (1, 2, 3)
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/avocado"
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/avocado/vecOneTwoThree"
[2021-06-16T20:04:15Z DEBUG caniput::ast] Parsed value vec { 1; 2; 3 }
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/avocado/oneTwoThree"
[2021-06-16T20:04:15Z DEBUG caniput::ast] Parsed args (1, 2, 3)
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/index"
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/banana"
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/banana/vecOneTwoThree"
[2021-06-16T20:04:15Z DEBUG caniput::ast] Parsed value vec { 1; 2; 3 }
[2021-06-16T20:04:15Z INFO  caniput::ast] Reading path "../../test/service/putTree/banana/oneTwoThree"
[2021-06-16T20:04:15Z DEBUG caniput::ast] Parsed args (1, 2, 3)
[2021-06-16T20:04:15Z INFO  caniput] Service (put):: Encoded argument via Candid; Arg size 751 bytes
[2021-06-16T20:04:15Z INFO  caniput] Service (put):: Awaiting response from service...
[2021-06-16T20:04:16Z DEBUG reqwest::async_impl::client] response '202 Accepted' for https://ic0.app/api/v2/canister/fzcsx-6yaaa-aaaae-aaama-cai/call
[2021-06-16T20:04:17Z DEBUG reqwest::async_impl::client] response '200 OK' for https://ic0.app/api/v2/canister/fzcsx-6yaaa-aaaae-aaama-cai/read_state
[2021-06-16T20:04:19Z DEBUG reqwest::async_impl::client] response '200 OK' for https://ic0.app/api/v2/canister/fzcsx-6yaaa-aaaae-aaama-cai/read_state
[2021-06-16T20:04:21Z INFO  caniput] Service (put):: Ok: Response size 10 bytes; elapsed time 5.840961s
[2021-06-16T20:04:21Z INFO  caniput] Put value successfully.
```