### PR TITLE
Feature: Each `put` has an ID. 

### DIFF
--- a/motoko/library/State.mo
+++ b/motoko/library/State.mo
@@ -117,6 +117,7 @@ module {
       public type PutValue = {
         id : Nat;
         time : Int;
+        caller : Principal;
         user : Types.UserId;
         path : Path;
         values : [ Types.Candid.Value.Value ];

--- a/motoko/library/State.mo
+++ b/motoko/library/State.mo
@@ -45,6 +45,7 @@ module {
       ttl : ?Nat;
     };
     public type Put = {
+      id : Nat;
       caller : Principal;
       user : Types.UserId;
       path : Path;
@@ -114,6 +115,7 @@ module {
     /// The data associated of a single put operation.
     public module PutValue {
       public type PutValue = {
+        id : Nat;
         time : Int;
         user : Types.UserId;
         path : Path;

--- a/motoko/library/State.mo
+++ b/motoko/library/State.mo
@@ -133,7 +133,6 @@ module {
 
     /// event log.
     eventLog : Event.Log;
-    var eventCount : Nat;
 
     /// all profiles.
     profiles : Map<Types.UserId, Profile>;
@@ -159,7 +158,6 @@ module {
       access = Access.Access({ admin = init.admin });
       profiles = TrieMap.TrieMap<Types.UserId, Profile>(Text.equal, Text.hash);
       eventLog = SeqObj.Seq<Event.Event>(Event.equal, null);
-      var eventCount = 0;
       spaces = TrieMap.TrieMap<Path, Space.Space>(Path.equal, Path.hash);
       views = TrieMap.TrieMap<Types.ViewId, View.View>(Text.equal, Text.hash);
       var viewCount = 0;

--- a/motoko/library/Types.mo
+++ b/motoko/library/Types.mo
@@ -195,6 +195,7 @@ public module View {
   /// It associates a time, user and path with a candid data sequence.
   /// A put value is an atomic "raw data" entry of a space, as viewed by a View.
   public type PutValues = {
+    caller : Principal;
     time : Timestamp;
     user : UserId;
     path : Space.Path.Path;

--- a/motoko/library/Types.mo
+++ b/motoko/library/Types.mo
@@ -5,6 +5,7 @@ public type Timestamp = Int; // See mo:base/Time and Time.now()
 
 public type UserId = Text; // chosen by createUser
 public type ViewId = Text; // chosen by createView
+public type PutId = Nat; // chosen by put
 
 /// Role for a caller into the service API.
 /// Common case is #user.

--- a/motoko/service/CandidSpaces.mo
+++ b/motoko/service/CandidSpaces.mo
@@ -28,8 +28,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
   var state = State.empty({ admin = initPrincipal });
 
   /// Stable memory-based event log
-  stable var eventLog : EventLog = Sequence.empty();
-  stable var eventCount : Nat = 0;
+  stable var eventLog_20210616_2042 : EventLog = Sequence.empty();
 
   /// Sequence for stable memory-based event log
   public type Sequence<X> = Sequence.Sequence<X>;
@@ -54,6 +53,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
 
   /// log the given event kind, with a unique ID and current time
   func logEvent(ek : State.Event.EventKind) {
+    let eventCount = Sequence.size(eventLog_20210616_2042);
     let e = {
       id = eventCount ;
       time = timeNow_() ;
@@ -61,16 +61,16 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
     };
 
     /// Stable memory log (full history).
-    eventLog := append<Event>(eventLog, Sequence.make(e));
-    eventCount += 1;
+    eventLog_20210616_2042 :=
+      append<Event>(eventLog_20210616_2042, Sequence.make(e));
 
     /// Flexible memory log (history since last upgrade).
     state.eventLog.add(e);
-    state.eventCount += 1;
   };
 
   /// Variation where event kind requires knowing the ID of the event.
   func logEvent_(ek_ : Nat -> State.Event.EventKind) {
+    let eventCount = Sequence.size(eventLog_20210616_2042);
     logEvent(ek_(eventCount))
   };
 
@@ -185,9 +185,9 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
 
 
   /// Put candid data into the space identified by the path.
-  public shared(msg) func get(putId : Types.PutId) : async ?Types.View.PutValues {
+  public query(msg) func get(putId : Types.PutId) : async ?Types.View.PutValues {
     do ? {
-      let event = Sequence.get(eventLog, putId)!;
+      let event = Sequence.get(eventLog_20210616_2042, putId)!;
       switch (event.kind) {
         case (#put(put)) {
                {
@@ -305,7 +305,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
     // 20210614-1712 to do -- access checks that filter out or redact the log.
     do ? {
       let tail = Buffer.Buffer<State.Event.Event>(0);
-      let iter = Sequence.iter(eventLog, #bwd);
+      let iter = Sequence.iter(eventLog_20210616_2042, #bwd);
       var count = 0;
       while (tail.size() < 10) {
         switch (iter.next()) {

--- a/motoko/service/CandidSpaces.mo
+++ b/motoko/service/CandidSpaces.mo
@@ -172,6 +172,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
       };
       space.puts.add(
         {
+          caller = msg.caller;
           id = putId!;
           path = path_;
           time = timeNow_();
@@ -182,6 +183,24 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
     }
   };
 
+
+  /// Put candid data into the space identified by the path.
+  public shared(msg) func get(putId : Types.PutId) : async ?Types.View.PutValues {
+    do ? {
+      let event = Sequence.get(eventLog, putId)!;
+      switch (event.kind) {
+        case (#put(put)) {
+               {
+                 caller = put.caller;
+                 path = put.path;
+                 time = event.time;
+                 user = put.user;
+                 values = put.values;
+               } };
+        case _ { return null }
+      }
+    }
+  };
 
   /// A view is an immutable representation of a gathering of paths' data.
   ///
@@ -269,6 +288,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
                 time = p.time ;
                 user = p.user ;
                 values = p.values ;
+                caller = p.caller ;
               })
       };
       { pos = 0;
@@ -309,6 +329,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
       let s = v.puts.slice(pos_, size_);
       for (p in s.vals()) {
         b.add({ path = p.path ;
+                caller = p.caller ;
                 time = p.time ;
                 user = p.user ;
                 values = p.values ;

--- a/rust/caniput/src/bin/caniput.rs
+++ b/rust/caniput/src/bin/caniput.rs
@@ -180,13 +180,16 @@ async fn service_call(ctx: &ConnectCtx, call: &ServiceCall) -> OurResult<()> {
             blob_res.len(),
             elapsed
         );
-        let result_flag: (Option<()>,) = candid::decode_args(&blob_res)?;
+        let result_flag: (Option<candid::Nat>,) = candid::decode_args(&blob_res)?;
         match result_flag {
             (None,) => error!("Failure to put."),
-            (Some(()),) => info!(
-                "Successful put: {} arg bytes; {:?} elapsed; completed.",
-                arg_bytes_len, elapsed
-            ),
+            (Some(put_id),) => {
+                info!(
+                    "Successful: putId={}; {} arg bytes; {:?} elapsed; completed.",
+                    put_id, arg_bytes_len, elapsed
+                );
+                println!("{}", put_id);
+            }
         };
         Ok(())
     } else {


### PR DESCRIPTION
- Issue IDs after each `put`.
- A corresponding `get` recovers the data from the `put`, plus meta data.