### PR TITLE
Feature: One-way put operation (faster).

### DIFF
--- a/motoko/library/Types.mo
+++ b/motoko/library/Types.mo
@@ -75,7 +75,7 @@ public type CandidSpacesActor = actor {
     values : [ Candid.Value.Value ] ) -> ();
 
   // query function (no mutation).
-  get : (putId : PutId) -> async ?View.PutValues query;
+  get : query (putId : PutId) -> async ?View.PutValues;
 };
 
 public module Candid {

--- a/motoko/library/Types.mo
+++ b/motoko/library/Types.mo
@@ -61,11 +61,21 @@ public module Space {
 };
 
 public type CandidSpacesActor = actor {
+  // response PutId uniquely identifies the put operation in a global log.
   put : (
     user : UserId,
     path : Space.Path.Path,
     values : [ Candid.Value.Value ] ) -> async ?PutId;
-  get : (putId : PutId) -> async ?View.PutValues;
+
+  // one-way function (no return value).
+  // (inspect the log later to see where it appears, and how it is identified).
+  putQuick : (
+    user : UserId,
+    path : Space.Path.Path,
+    values : [ Candid.Value.Value ] ) -> ();
+
+  // query function (no mutation).
+  get : (putId : PutId) -> async ?View.PutValues query;
 };
 
 public module Candid {

--- a/motoko/service/CandidSpaces.mo
+++ b/motoko/service/CandidSpaces.mo
@@ -135,7 +135,17 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
   };
 
   /// Put candid data into the space identified by the path.
+  public shared(msg) func putQuick(user_ : UserId, path_ : SpacePath, values_ : [ CandidValue ]) {
+    ignore put_(msg.caller, user_, path_, values_);
+  };
+
+  /// Put candid data into the space identified by the path.
   public shared(msg) func put(user_ : UserId, path_ : SpacePath, values_ : [ CandidValue ]) : async ?Types.PutId {
+    put_(msg.caller, user_, path_, values_);
+  };
+
+  /// Put candid data into the space identified by the path.
+  func put_(caller_ : Principal, user_ : UserId, path_ : SpacePath, values_ : [ CandidValue ]) : ?Types.PutId {
     do ? {
       // to do --
       // access control for spaces,
@@ -149,7 +159,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
         func (id_ : Nat) : State.Event.EventKind {
           putId := ?id_;
           #put({ id = id_;
-                 caller = msg.caller;
+                 caller = caller_;
                  user = user_;
                  path = path_;
                  values = values_})
@@ -159,7 +169,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
         case null {
                // space does not exist; create it now.
                let space = {
-                 createCaller = msg.caller;
+                 createCaller = caller_;
                  createUser = user_;
                  createTime = timeNow_();
                  path = path_ ;
@@ -172,7 +182,7 @@ shared ({caller = initPrincipal}) actor class CandidSpaces () {
       };
       space.puts.add(
         {
-          caller = msg.caller;
+          caller = caller_;
           id = putId!;
           path = path_;
           time = timeNow_();

--- a/motoko/service/DemoDoer.mo
+++ b/motoko/service/DemoDoer.mo
@@ -56,19 +56,22 @@ actor {
     await doStateChange(#Nat n)
   };
 
-  public func putTextQuick(t : Text) : async ?() {
+  // one-way function, calling a one-way function
+  public func putTextQuick(t : Text) : () {
     ourState := #Text t;
     logger.putQuick("demoDoer", ["demo", "state"], [ #Text t ]);
     ?()
   };
 
-  public func putBoolQuicker(b : Bool) : async ?() {
+  // one-way function, calling a one-way function
+  public func putBoolQuick(b : Bool) : () {
     ourState := #Bool b;
     logger.putQuick("demoDoer", ["demo", "state"], [ #Bool b ]);
     ?()
   };
 
-  public func putNatQuicker(n : Nat) : async ?() {
+  // one-way function, calling a one-way function
+  public func putNatQuick(n : Nat) : () {
     ourState := #Nat n;
     logger.putQuick("demoDoer", ["demo", "state"], [ #Nat n ]);
     ?()

--- a/motoko/service/DemoDoer.mo
+++ b/motoko/service/DemoDoer.mo
@@ -41,7 +41,7 @@ actor {
       ourState := newState;
       // Notice: no await here! --- So, should be quicker than non-Quick version.
       // Trade-off is that the put result is not available until we do await it, and we dont.
-      let _ = logger.put("demoDoer", ["demo", "state"], [ newState ]);
+      logger.putQuick("demoDoer", ["demo", "state"], [ newState ]);
     };
   };
 

--- a/motoko/service/DemoDoer.mo
+++ b/motoko/service/DemoDoer.mo
@@ -60,20 +60,17 @@ actor {
   public func putTextQuick(t : Text) : () {
     ourState := #Text t;
     logger.putQuick("demoDoer", ["demo", "state"], [ #Text t ]);
-    ?()
   };
 
   // one-way function, calling a one-way function
   public func putBoolQuick(b : Bool) : () {
     ourState := #Bool b;
     logger.putQuick("demoDoer", ["demo", "state"], [ #Bool b ]);
-    ?()
   };
 
   // one-way function, calling a one-way function
   public func putNatQuick(n : Nat) : () {
     ourState := #Nat n;
     logger.putQuick("demoDoer", ["demo", "state"], [ #Nat n ]);
-    ?()
   };
 }

--- a/motoko/service/DemoDoer.mo
+++ b/motoko/service/DemoDoer.mo
@@ -36,15 +36,6 @@ actor {
     };
   };
 
-  func doStateChangeQuick(newState : OurState) : async ?() {
-    do ? {
-      ourState := newState;
-      // Notice: no await here! --- So, should be quicker than non-Quick version.
-      // Trade-off is that the put result is not available until we do await it, and we dont.
-      logger.putQuick("demoDoer", ["demo", "state"], [ newState ]);
-    };
-  };
-
   public query func getState() : async ?{state : OurState; logPuts : [PutId]}
   {
     ?{ state = ourState ;
@@ -64,14 +55,20 @@ actor {
   };
 
   public func putTextQuick(t : Text) : async ?() {
-    await doStateChangeQuick(#Text t)
+    ourState := #Text t;
+    logger.putQuick("demoDoer", ["demo", "state"], [ #Text t ]);
+    ?()
   };
 
   public func putBoolQuicker(b : Bool) : async ?() {
-    await doStateChangeQuick(#Bool b)
+    ourState := #Bool b;
+    logger.putQuick("demoDoer", ["demo", "state"], [ #Bool b ]);
+    ?()
   };
 
   public func putNatQuicker(n : Nat) : async ?() {
-    await doStateChangeQuick(#Nat n)
+    ourState := #Nat n;
+    logger.putQuick("demoDoer", ["demo", "state"], [ #Nat n ]);
+    ?()
   };
 }

--- a/motoko/service/DemoDoer.mo
+++ b/motoko/service/DemoDoer.mo
@@ -9,7 +9,9 @@ actor {
   type Logger = Types.CandidSpacesActor;
 
   let logger : Logger =
-    (actor "rrkah-fqaaa-aaaaa-aaaaq-cai" /*"fzcsx-6yaaa-aaaae-aaama-cai"*/
+    (actor
+     /* "rrkah-fqaaa-aaaaa-aaaaq-cai" */
+        "fzcsx-6yaaa-aaaae-aaama-cai"
        : Logger);
 
   public type PutId = Types.PutId;


### PR DESCRIPTION
Experimenting with the CandidSpaces actor signature.

In particular, I failed to get one-way `put` operations to work last week for a small internal demo, and now I want to investigate what I did to interfere with that intended behavior.

So far:

- failed to remember that the caller must declare the function as one way by explicitly annotating the return type as having no information (type `()`) instead of the default, `async ()`.   This PR fixes that oversight, I believe.

- used an `await` within the code just to do function abstraction for the `put` and share code (does it go through the system event loop, or not?  Uncertain.)  Removed this utility function and duplicated its code (inlined).  This PR removes this `await`.

- used blocking versions of the `DemoDoer`'s API.  This PR changes the `Quick` versions everywhere to be one-way, including in `DemoDoer`.